### PR TITLE
Use PropTypes from prop-types package instead of from react

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-dom": "^15.3.2"
   },
   "dependencies": {
-    "@aneves/js-closest": "^0.1.3"
+    "@aneves/js-closest": "^0.1.3",
+    "prop-types": "^15.5.10"
   },
   "scripts": {
     "build": "npm run build-css && npm run build-js && npm run copy-to-example",

--- a/src/Flyout.jsx
+++ b/src/Flyout.jsx
@@ -208,13 +208,13 @@ class Flyout extends React.Component {
 
                 // check the max-height possible
                 let newFlyoutMaxHeight = windowHeight - (flyoutOffsetTop) - this._getMaxHeightOffset(getMaxHeightOffsetPosition);
-                
+
                 // verify it against a possible setted max-height
                 if (flyoutMaxHeight !== 0 && newFlyoutMaxHeight >= flyoutMaxHeight) return false;
 
                 // removing min-height for extreme cases
                 if (newFlyoutMaxHeight < flyoutMinHeight) flyout.style.minHeight = 0;
-                
+
                 // set new max-height
                 flyoutContent.style.maxHeight = newFlyoutMaxHeight +'px';
 
@@ -317,7 +317,7 @@ class Flyout extends React.Component {
             this.body.setAttribute('data-flyoutBodyScrollPosition', window.pageYOffset);
         }
     }
-    
+
     _scrollPositionLoad() {
         // console.info('flyout - _loadScrollPosition');
         if (this.body.classList && !this.body.classList.contains('has-flyout--fixed')) return false;

--- a/src/FlyoutWrapper.jsx
+++ b/src/FlyoutWrapper.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Flyout from './Flyout';
@@ -58,9 +59,9 @@ class FlyoutWrapper extends React.Component {
 }
 
 FlyoutWrapper.propTypes = {
-    id: React.PropTypes.string.isRequired,
-    open: React.PropTypes.bool,
-    options: React.PropTypes.object
+    id: PropTypes.string.isRequired,
+    open: PropTypes.bool,
+    options: PropTypes.object
 };
 
 FlyoutWrapper.defaultProps = {


### PR DESCRIPTION
To fix a "lowPriorityWarning" that appears in `console.warn` when react-flyout is used in React v15:

> lowPriorityWarning.js:40 Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs